### PR TITLE
feat: expose control of # of iterations during NL estimation

### DIFF
--- a/include/opengv/absolute_pose/methods.hpp
+++ b/include/opengv/absolute_pose/methods.hpp
@@ -297,7 +297,7 @@ transformations_t upnp(
  *         from viewpoint to world frame, transforms points from viewpoint to
  *         world frame).
  */
-transformation_t optimize_nonlinear( const AbsoluteAdapterBase & adapter );
+transformation_t optimize_nonlinear( const AbsoluteAdapterBase & adapter, size_t iterations=1000 );
 
 /**
  * \brief Compute the pose of a viewpoint using nonlinear optimization. Works
@@ -314,7 +314,8 @@ transformation_t optimize_nonlinear( const AbsoluteAdapterBase & adapter );
  */
 transformation_t optimize_nonlinear(
     const AbsoluteAdapterBase & adapter,
-    const std::vector<int> & indices );
+    const std::vector<int> & indices,
+    size_t iterations=1000 );
 
 }
 }

--- a/include/opengv/point_cloud/methods.hpp
+++ b/include/opengv/point_cloud/methods.hpp
@@ -95,7 +95,7 @@ transformation_t threept_arun(
  *         frame 1, and \f$ \mathbf{R} \f$ being the rotation from
  *         frame 2 to frame 1).
  */
-transformation_t optimize_nonlinear( PointCloudAdapterBase & adapter );
+transformation_t optimize_nonlinear( PointCloudAdapterBase & adapter, size_t iterations=1000 );
 
 /**
  * \brief Compute the transformation between two frames containing point clouds.
@@ -112,7 +112,8 @@ transformation_t optimize_nonlinear( PointCloudAdapterBase & adapter );
  */
 transformation_t optimize_nonlinear(
     PointCloudAdapterBase & adapter,
-    const std::vector<int> & indices );
+    const std::vector<int> & indices,
+    size_t iterations=1000 );
 
 }
 }

--- a/include/opengv/relative_pose/methods.hpp
+++ b/include/opengv/relative_pose/methods.hpp
@@ -482,7 +482,7 @@ transformation_t seventeenpt(
  *         viewpoint 1, and \f$ \mathbf{R} \f$ being the rotation from
  *         viewpoint 2 to viewpoint 1).
  */
-transformation_t optimize_nonlinear( RelativeAdapterBase & adapter );
+transformation_t optimize_nonlinear( RelativeAdapterBase & adapter, size_t iterations=1000 );
 
 /**
  * \brief Compute the pose between two viewpoints using nonlinear optimization.
@@ -499,7 +499,8 @@ transformation_t optimize_nonlinear( RelativeAdapterBase & adapter );
  */
 transformation_t optimize_nonlinear(
     RelativeAdapterBase & adapter,
-    const std::vector<int> & indices );
+    const std::vector<int> & indices,
+    size_t iterations=1000 );
 
 }
 }

--- a/python/pyopengv.cpp
+++ b/python/pyopengv.cpp
@@ -246,11 +246,12 @@ py::object upnp( pyarray_d &v, pyarray_d &p )
 py::object optimize_nonlinear( pyarray_d &v,
                                pyarray_d &p,
                                pyarray_d &t,
-                               pyarray_d &R )
+                               pyarray_d &R,
+                               size_t iterations )
 {
   CentralAbsoluteAdapter adapter(v, p, t, R);
   return arrayFromTransformation(
-    opengv::absolute_pose::optimize_nonlinear(adapter));
+    opengv::absolute_pose::optimize_nonlinear(adapter,iterations));
 }
 
 py::object ransac(
@@ -487,11 +488,12 @@ py::object sixpt( pyarray_d &b1, pyarray_d &b2 )
 py::object optimize_nonlinear( pyarray_d &b1,
                                pyarray_d &b2,
                                pyarray_d &t12,
-                               pyarray_d &R12 )
+                               pyarray_d &R12,
+                               size_t iterations )
 {
   CentralRelativeAdapter adapter(b1, b2, t12, R12);
   return arrayFromTransformation(
-    opengv::relative_pose::optimize_nonlinear(adapter));
+    opengv::relative_pose::optimize_nonlinear(adapter,iterations));
 }
 
 py::object ransac(

--- a/python/tests.py
+++ b/python/tests.py
@@ -173,7 +173,7 @@ def test_relative_pose():
         d.bearing_vectors1, d.bearing_vectors2, R_perturbed)
     t_perturbed, R_perturbed = getPerturbedPose(d.position, d.rotation, 0.1)
     nonlinear_transformation = pyopengv.relative_pose_optimize_nonlinear(
-        d.bearing_vectors1, d.bearing_vectors2, t_perturbed, R_perturbed)
+        d.bearing_vectors1, d.bearing_vectors2, t_perturbed, R_perturbed, 1000)
 
     assert proportional(d.position, twopt_translation)
     assert matrix_in_list(d.essential, fivept_nister_essentials)

--- a/src/absolute_pose/methods.cpp
+++ b/src/absolute_pose/methods.cpp
@@ -766,7 +766,8 @@ struct OptimizeNonlinearFunctor1 : OptimizationFunctor<double>
 
 transformation_t optimize_nonlinear(
     const AbsoluteAdapterBase & adapter,
-    const Indices & indices )
+    const Indices & indices,
+    size_t iterations )
 {
   const int n=6;
   VectorXd x(n);
@@ -781,7 +782,7 @@ transformation_t optimize_nonlinear(
   lm.resetParameters();
   lm.parameters.ftol = 1.E1*NumTraits<double>::epsilon();
   lm.parameters.xtol = 1.E1*NumTraits<double>::epsilon();
-  lm.parameters.maxfev = 1000;
+  lm.parameters.maxfev = iterations;
   lm.minimize(x);
 
   transformation_t transformation;
@@ -794,17 +795,20 @@ transformation_t optimize_nonlinear(
 }
 
 opengv::transformation_t
-opengv::absolute_pose::optimize_nonlinear( const AbsoluteAdapterBase & adapter )
+opengv::absolute_pose::optimize_nonlinear( 
+    const AbsoluteAdapterBase & adapter, 
+    size_t iterations )
 {
   Indices idx(adapter.getNumberCorrespondences());
-  return optimize_nonlinear(adapter,idx);
+  return optimize_nonlinear(adapter,idx, iterations);
 }
 
 opengv::transformation_t
 opengv::absolute_pose::optimize_nonlinear(
     const AbsoluteAdapterBase & adapter,
-    const std::vector<int> & indices )
+    const std::vector<int> & indices,
+    size_t iterations )
 {
   Indices idx(indices);
-  return optimize_nonlinear(adapter,idx);
+  return optimize_nonlinear(adapter,idx, iterations);
 }

--- a/src/point_cloud/methods.cpp
+++ b/src/point_cloud/methods.cpp
@@ -149,7 +149,8 @@ struct OptimizeNonlinearFunctor1 : OptimizationFunctor<double>
 
 transformation_t optimize_nonlinear(
     PointCloudAdapterBase & adapter,
-    const Indices & indices )
+    const Indices & indices,
+    size_t iterations )
 {
   const int n=6;
   VectorXd x(n);
@@ -164,7 +165,7 @@ transformation_t optimize_nonlinear(
   lm.resetParameters();
   lm.parameters.ftol = 1.E10*NumTraits<double>::epsilon();
   lm.parameters.xtol = 1.E10*NumTraits<double>::epsilon();
-  lm.parameters.maxfev = 1000;
+  lm.parameters.maxfev = iterations;
   lm.minimize(x);
 
   transformation_t transformation;
@@ -177,17 +178,20 @@ transformation_t optimize_nonlinear(
 }
 
 opengv::transformation_t
-opengv::point_cloud::optimize_nonlinear( PointCloudAdapterBase & adapter )
+opengv::point_cloud::optimize_nonlinear( 
+    PointCloudAdapterBase & adapter,
+    size_t iterations )
 {
   Indices idx(adapter.getNumberCorrespondences());
-  return optimize_nonlinear(adapter,idx);
+  return optimize_nonlinear(adapter,idx,iterations);
 }
 
 opengv::transformation_t
 opengv::point_cloud::optimize_nonlinear(
     PointCloudAdapterBase & adapter,
-    const std::vector<int> & indices )
+    const std::vector<int> & indices,
+    size_t iterations )
 {
   Indices idx(indices);
-  return optimize_nonlinear(adapter,idx);
+  return optimize_nonlinear(adapter,idx,iterations);
 }

--- a/src/relative_pose/methods.cpp
+++ b/src/relative_pose/methods.cpp
@@ -1151,7 +1151,8 @@ struct OptimizeNonlinearFunctor1 : OptimizationFunctor<double>
 
 transformation_t optimize_nonlinear(
     RelativeAdapterBase & adapter,
-    const Indices & indices )
+    const Indices & indices,
+    size_t iterations )
 {
   const int n=6;
   VectorXd x(n);
@@ -1167,7 +1168,7 @@ transformation_t optimize_nonlinear(
   lm.resetParameters();
   lm.parameters.ftol = 1.E1*NumTraits<double>::epsilon();
   lm.parameters.xtol = 1.E1*NumTraits<double>::epsilon();
-  lm.parameters.maxfev = 1000;
+  lm.parameters.maxfev = iterations;
   lm.minimize(x);
 
   transformation_t transformation;
@@ -1180,17 +1181,20 @@ transformation_t optimize_nonlinear(
 }
 
 opengv::transformation_t
-opengv::relative_pose::optimize_nonlinear( RelativeAdapterBase & adapter )
+opengv::relative_pose::optimize_nonlinear( 
+    RelativeAdapterBase & adapter,
+    size_t iterations )
 {
   Indices idx(adapter.getNumberCorrespondences());
-  return optimize_nonlinear(adapter,idx);
+  return optimize_nonlinear(adapter,idx,iterations);
 }
 
 opengv::transformation_t
 opengv::relative_pose::optimize_nonlinear(
     RelativeAdapterBase & adapter,
-    const std::vector<int> & indices )
+    const std::vector<int> & indices,
+    size_t iterations )
 {
   Indices idx(indices);
-  return optimize_nonlinear(adapter,idx);
+  return optimize_nonlinear(adapter,idx,iterations);
 }


### PR DESCRIPTION
This PR aims at exposing the # of iterations done during the non-linear refinement of the relative pose estimation. We keep the legacy-1K iterations as default parameters.

This is the first PR, we merge it in `opensfm` which was fetched from `paulinus/opengv/master`. We're going to keep the `opensfm` branch as feature branch for our own use, while `master` in track with the main `opengv` repository.